### PR TITLE
Add missing aesmd library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get update && apt-get install --no-install-recommends -qq -y \
   libsgx-dcap-ql \
   libsgx-dcap-default-qpl \
   sgx-aesm-service \
+  libsgx-aesm-quote-ex-plugin \
   && rm -rf /var/lib/apt/lists/*
 
 # SGX SDK is installed in /opt/intel directory.


### PR DESCRIPTION
This library was missing and leaded to following error:
```
error: aesm_service returned error: 30
error: load_enclave() failed with error -1
```